### PR TITLE
Change Video component 'rate' prop type from string to float

### DIFF
--- a/src/Video.re
+++ b/src/Video.re
@@ -90,7 +90,7 @@ let make =
     (
       ~source=`NullSource,
       ~posterSource=`NullSource,
-      ~rate: option(string)=?,
+      ~rate: option(float)=?,
       ~isMuted=false,
       ~useNativeControls=false,
       ~resizeMode=COVER,


### PR DESCRIPTION
This fixes the issue https://github.com/FiberJW/reason-expo/issues/6