### PR TITLE
bug(camera): get correct constants from FaceDector-package

### DIFF
--- a/src/Camera.re
+++ b/src/Camera.re
@@ -43,29 +43,27 @@ module Constants = {
 
   module FaceDetection = {
     module Mode = {
-      [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Mode")]
+      [@bs.module "expo"] [@bs.scope ("FaceDetector", "Constants", "Mode")]
       external fast: t = "fast";
-      [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Mode")]
+      [@bs.module "expo"] [@bs.scope ("FaceDetector", "Constants", "Mode")]
       external accurate: t = "accurate";
     };
 
     module Landmarks = {
       [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Landmarks")]
+      [@bs.scope ("FaceDetector", "Constants", "Landmarks")]
       external all: t = "all";
       [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Landmarks")]
+      [@bs.scope ("FaceDetector", "Constants", "Landmarks")]
       external none: t = "none";
     };
 
     module Classifications = {
       [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Classifications")]
+      [@bs.scope ("FaceDetector", "Constants", "Classifications")]
       external all: t = "all";
       [@bs.module "expo"]
-      [@bs.scope ("Camera", "Constants", "FaceDetection", "Classifications")]
+      [@bs.scope ("FaceDetector", "Constants", "Classifications")]
       external none: t = "none";
     };
   };


### PR DESCRIPTION
This will fetch [existing constants from FaceDetector-package](https://docs.expo.io/versions/latest/sdk/facedetector/#arguments). In SDK v29 of Expo, constants seems to have been moved from `Camera.Constants.FaceDetection.*` to `FaceDetector.Constants.*`.

Without this fix I get the following error:
```
TypeError: undefined is not an object (evaluating 'Expo.Camera.Constants.FaceDetection.Classifications')
```

I checked the Camera documentation for all the SDK versions, and there is a big change between [v28](https://docs.expo.io/versions/v28.0.0/sdk/camera/) and [v29](https://docs.expo.io/versions/v29.0.0/sdk/camera/), but I couldn't find anything about this in the [blog post for v29](https://blog.expo.io/expo-sdk-v29-0-0-is-now-available-f001d77fadf). Silent breaking change? I also checked the git-blame/-history for [`expo/packages/expo-camera/src`](https://github.com/expo/expo/commits/8864b1cd7ce15f5f9e058360d6474e2d02d455fd/packages/expo-camera/src), but it seems like there have been some refactoring that makes this difficult.

So while this PR does fix the type error, it does not fix compability with Expo SDK, since it from v29 and onwards expects a settings object containing all the face detection settings (as was previously sent as individual props to the `Camera`-component).