### PR TITLE
Update to reason-react-native

### DIFF
--- a/template/bsconfig.json
+++ b/template/bsconfig.json
@@ -1,13 +1,14 @@
 {
   "name": "my-reason-expo-app",
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "bsc-flags": ["-bs-super-errors"],
-  "bs-dependencies": ["bs-react-native", "reason-react", "reason-expo"],
+  "bs-dependencies": ["reason-react", "reason-expo", "reason-react-native"],
   "sources": [
     {
-      "dir": "src"
+      "dir": "src",
+      "subdirs": true
     }
   ],
   "suffix": ".bs.js",

--- a/template/package.json
+++ b/template/package.json
@@ -20,12 +20,13 @@
   },
   "dependencies": {
     "bs-platform": "^5.0.4",
-    "bs-react-native": "^0.10.0",
     "expo": "^33.0.0",
     "react": "16.8.3",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
+    "react-native":
+      "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
     "reason-expo": "^33.1.0",
-    "reason-react": "^0.7.0"
+    "reason-react": "https://github.com/reasonml/reason-react.git#835b90c",
+    "reason-react-native": "^0.60.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0"

--- a/template/src/App.re
+++ b/template/src/App.re
@@ -1,22 +1,19 @@
-open BsReactNative;
+open ReactNative;
 
-let component = ReasonReact.statelessComponent("App");
+let styles =
+  Style.(
+    StyleSheet.create({
+      "root":
+        viewStyle(~flex=1., ~justifyContent=`center, ~alignItems=`center, ()),
+      "text": textStyle(~color="white", ()),
+      "gradient": viewStyle(~padding=12.->dp, ~borderRadius=12., ()),
+    })
+  );
 
-let make = _children => {
-  ...component,
-  render: _self =>
-    <View
-      style=Style.(
-        style([flex(1.), justifyContent(Center), alignItems(Center)])
-      )>
-      <ReasonExpo.LinearGradient
-        colors=[|"#DD4B39", "#C62C19"|]
-        style=Style.(style([padding(Pt(12.)), borderRadius(12.)]))>
-        <Text style=Style.(style([color(String("white"))]))>
-          {ReasonReact.string("To get started, edit App.re")}
-        </Text>
-      </ReasonExpo.LinearGradient>
-    </View>,
-};
-
-let default = ReasonReact.wrapReasonForJs(~component, _jsProps => make([||]));
+[@react.component]
+let make = () =>
+  <View style=styles##root>
+    <Text style=styles##text>
+      {ReasonReact.string("To get started, edit App.re")}
+    </Text>
+  </View>;

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -1334,16 +1334,6 @@ bs-platform@^5.0.4:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
 
-bs-react-native-jsx3-compat@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/bs-react-native-jsx3-compat/-/bs-react-native-jsx3-compat-0.11.1.tgz#643699594056e14dc61a719d0741b9c94d0c08fe"
-  integrity sha512-/+2DaxWBlRwjGP7luqn3hPWwcgabCm3uzRay6ly/md0JCSb/xsF4KgsS6VMHx0rZsndT81AfidlKb4rRQEaKUg==
-
-bs-react-native@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/bs-react-native/-/bs-react-native-0.11.1.tgz#1e0ec167cc6a73d64106b9165361b9a2e1a796ce"
-  integrity sha512-gjuZERFsOLCr3FwXnhsjbAd0AXT89gS+fpIDRkO0XFiQvnUxYNkXiTDzJfeYGAam0lrrxtKB+9l+bVHHh5Awiw==
-
 bser@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
@@ -4616,11 +4606,6 @@ reason-expo@^33.1.0:
   version "33.1.0"
   resolved "https://registry.yarnpkg.com/reason-expo/-/reason-expo-33.1.0.tgz#e2d93140ed4e914b4ef2bd688bc0c347f66b8121"
   integrity sha512-4kexs4Pdic2MJthqGYrtJWosG/X6+Z4bAUibL3vuYiOJ25yIE49z6e9+r2Xp3CFKzlTqSDCImdHqEkZVi8oCYA==
-
-reason-react-compat@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/reason-react-compat/-/reason-react-compat-0.4.0.tgz#9c6705f9bd67e7ff7219355f3a95fd67442b578d"
-  integrity sha512-Bwwgb6AHusLiRhdd0aupFAuMYaG3gnwR6iHYYlj9gfLD6Uxp53dtJIhS2ZMTEpCSU1JE2X0k7x3rru1IRdx9FQ==
 
 reason-react-native@^0.60.0:
   version "0.60.0"

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -1334,10 +1334,15 @@ bs-platform@^5.0.4:
   resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.4.tgz#d406ef43c12d1b19d8546884d8b5b4e0fb709372"
   integrity sha512-rXM+ztN8wYXQ4ojfFGylvPOf8GRLOvM94QJsMMV9VpsLChKCjesWMNybTZvpoyNsESu2nC5q+C9soG+BPhuUFQ==
 
-bs-react-native@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/bs-react-native/-/bs-react-native-0.10.0.tgz#4a9167cbe4c858008a9e56a0f745ba723c74101c"
-  integrity sha512-QpSbKwuYbDU1qBrxplmKvO8TZOtK2DpevoOUxDm0NfMNAdF6oacSbJfqMx89n2eGzMm8imZ3JsUeZPl6OT2N4A==
+bs-react-native-jsx3-compat@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/bs-react-native-jsx3-compat/-/bs-react-native-jsx3-compat-0.11.1.tgz#643699594056e14dc61a719d0741b9c94d0c08fe"
+  integrity sha512-/+2DaxWBlRwjGP7luqn3hPWwcgabCm3uzRay6ly/md0JCSb/xsF4KgsS6VMHx0rZsndT81AfidlKb4rRQEaKUg==
+
+bs-react-native@^0.11.1:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/bs-react-native/-/bs-react-native-0.11.1.tgz#1e0ec167cc6a73d64106b9165361b9a2e1a796ce"
+  integrity sha512-gjuZERFsOLCr3FwXnhsjbAd0AXT89gS+fpIDRkO0XFiQvnUxYNkXiTDzJfeYGAam0lrrxtKB+9l+bVHHh5Awiw==
 
 bser@^2.0.0:
   version "2.0.0"
@@ -4607,13 +4612,24 @@ readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-reason-expo@../:
-  version "33.0.0"
+reason-expo@^33.1.0:
+  version "33.1.0"
+  resolved "https://registry.yarnpkg.com/reason-expo/-/reason-expo-33.1.0.tgz#e2d93140ed4e914b4ef2bd688bc0c347f66b8121"
+  integrity sha512-4kexs4Pdic2MJthqGYrtJWosG/X6+Z4bAUibL3vuYiOJ25yIE49z6e9+r2Xp3CFKzlTqSDCImdHqEkZVi8oCYA==
 
-reason-react@^0.7.0:
+reason-react-compat@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/reason-react-compat/-/reason-react-compat-0.4.0.tgz#9c6705f9bd67e7ff7219355f3a95fd67442b578d"
+  integrity sha512-Bwwgb6AHusLiRhdd0aupFAuMYaG3gnwR6iHYYlj9gfLD6Uxp53dtJIhS2ZMTEpCSU1JE2X0k7x3rru1IRdx9FQ==
+
+reason-react-native@^0.60.0:
+  version "0.60.0"
+  resolved "https://registry.yarnpkg.com/reason-react-native/-/reason-react-native-0.60.0.tgz#7adb9837f28d79d9f1e009b5d01ae864aff15d51"
+  integrity sha512-7vq7KIaY1kGb5xnWVewuy8ttBx7/HAgeKfiwDYV3rij6Z89vU6QIheR6rENV8UxaKwRN/Gw168ladWLM042k9A==
+
+"reason-react@https://github.com/reasonml/reason-react.git#835b90c":
   version "0.7.0"
-  resolved "https://registry.yarnpkg.com/reason-react/-/reason-react-0.7.0.tgz#46a975c321e81cd51310d7b1a02418ca7667b0d6"
-  integrity sha512-czR/f0lY5iyLCki9gwftOFF5Zs40l7ZSFmpGK/Z6hx2jBVeFDmIiXB8bAQW/cO6IvtuEt97OmsYueiuOYG9XjQ==
+  resolved "https://github.com/reasonml/reason-react.git#835b90c1c73827632a9819a353a404380724b1d2"
   dependencies:
     react ">=16.8.1"
     react-dom ">=16.8.1"


### PR DESCRIPTION
Hello !

I've updated the template to support the latest version of `bs-react-native` which is `reason-react-native` [now](https://reasonml-community.github.io/reason-react-native/en/blog/2019-06-17-hello-reason-react-native/)

Every bindings must be updated, it's a lot of work sadly, I'll try to take some times to update the maximum I can.

What do you think ?