### PR TITLE
'expo-linear-gradient' import is not needed on modular imports

### DIFF
--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -14,7 +14,6 @@
     "bs-platform": "^5.0.4",
     "bs-react-native": "^0.10.0",
     "expo": "^33.0.0",
-    "expo-linear-gradient": "^5.0.1",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
     "reason-expo": "^33.2.0",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -23,7 +23,6 @@
     "bs-platform": "^5.0.4",
     "bs-react-native": "^0.10.0",
     "expo": "^33.0.0",
-    "expo-linear-gradient": "^5.0.1",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
     "reason-expo": "^33.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ expo-keep-awake@~5.0.1:
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-5.0.1.tgz#15aeffd9de673f7eaf145449883e8d83f7d7a799"
   integrity sha512-DPWAqgxbmLyJoCXPbDXbj+1XFjP/ulv4AYzvi1a+jsvZRU2uiFdho0w269Y++DLCQf30vbuu3zs5HiaJGU43fA==
 
-expo-linear-gradient@^5.0.1, expo-linear-gradient@~5.0.1:
+expo-linear-gradient@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/expo-linear-gradient/-/expo-linear-gradient-5.0.1.tgz#b4f5450d680b9315f22f4f99fee6a2b90fb49d92"
   integrity sha512-5dKn9JIXmXXHq6itC/Jpqo65Tkgjwacyw1kpD8sekoFTEVfT6ciFd2djqIcciUqIa57FF/5d2q54mUvjoqD/TA==


### PR DESCRIPTION
As I understanded, this dependency is no longer needed with the recent edition of this library. I tried to install/run without this dependency, and it worked as expected.