### PR TITLE
Fix Notifications.createCategoryAsync - use Js.t instead of ocaml object

### DIFF
--- a/packages/reason-expo/src/Notifications.re
+++ b/packages/reason-expo/src/Notifications.re
@@ -69,16 +69,16 @@ external createCategoryAsync:
     string,
     array({
       .
-      actionId: string,
-      buttonTitle: string,
-      textInput:
+      "actionId": string,
+      "buttonTitle": string,
+      "textInput":
         Js.Undefined.t({
           .
-          submitButtonTitle: string,
-          placeholder: string,
+          "submitButtonTitle": string,
+          "placeholder": string,
         }),
-      isDestructive: bool,
-      isAuthenticationRequired: bool,
+      "isDestructive": bool,
+      "isAuthenticationRequired": bool,
     })
   ) =>
   Js.Promise.t(unit) =


### PR DESCRIPTION
The following compiles but raises an error when running.
```
  Notifications.createCategoryAsync(
    "breakfast",
    [|
      {
        as _;
        pub actionId = "toast";
        pub buttonTitle = "I had toast";
        pub textInput = Js.Undefined.empty;
        pub isDestructive = false;
        pub isAuthenticationRequired = false
      },
    |],
  );
```

This PR changes the type to allow
```
Notifications.createCategoryAsync(
  "breakfast",
  [|
    {
      "actionId": "toast",
      "buttonTitle": "I had toast",
      "textInput": Js.Undefined.empty,
      "isDestructive": false,
      "isAuthenticationRequired": false,
    },
  |],
);
```
which does work correctly at runtime