### PR TITLE
Update AppLoading binding to use new annotation

### DIFF
--- a/packages/reason-expo/src/AppLoading.re
+++ b/packages/reason-expo/src/AppLoading.re
@@ -1,26 +1,11 @@
-[@bs.deriving abstract]
-type props = {
-  [@bs.optional]
-  startAsync: unit => Js.Promise.t(unit),
-  [@bs.optional]
-  onError: string => unit,
-  [@bs.optional]
-  onFinish: unit => unit,
-  [@bs.optional]
-  autoHideSplash: bool,
-  [@bs.optional]
-  children: React.element,
-};
-
-let makeProps =
-    (
-      ~startAsync=() => Js.Promise.resolve(),
-      ~onError=_error => (),
-      ~onFinish=() => (),
-      ~autoHideSplash=true,
-      ~children,
-    ) =>
-  props(~startAsync, ~onError, ~onFinish, ~autoHideSplash, ~children);
-
 [@bs.module "expo"] [@react.component]
-external make: props => React.element = "AppLoading";
+external make:
+  (
+    ~startAsync: unit => Js.Promise.t(unit)=?,
+    ~onError: string => unit=?,
+    ~onFinish: unit => unit=?,
+    ~autoHideSplash: bool=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "AppLoading";


### PR DESCRIPTION
I had some difficulty use `AppLoading` so I tried tweaking the binding and now it works pretty well.