### PR TITLE
Add @expo/vector-icons bindings

### DIFF
--- a/packages/reason-expo/src/VectorIcons.re
+++ b/packages/reason-expo/src/VectorIcons.re
@@ -1,0 +1,47 @@
+module MaterialIcons = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "MaterialIcons";
+};
+
+module Ionicons = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "Ionicons";
+};
+
+module Entypo = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "Entypo";
+};
+
+module EvilIcons = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "EvilIcons";
+};
+
+module FontAwesome = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "FontAwesome";
+};
+
+module Foundation = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "Foundation";
+};
+
+module MaterialCommunityIcons = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "MaterialCommunityIcons";
+};
+
+module Octicons = {
+  [@bs.module "@expo/vector-icons"] [@react.component]
+  external make: (~name: string, ~size: int, ~color: string) => React.element =
+    "Octicons";
+};


### PR DESCRIPTION
Hey Juwan,

Added these a while back to learn a bit more about Reason. Not sure if they're correct or should even be in this repo.

I noticed a while later that [this repo](https://redex.github.io/package/reason-expo-vector-icons/) also exists which kind of nullifies the point.

So feel free to close this if appropriate.