### PR TITLE
Update Google bindings

### DIFF
--- a/packages/reason-expo/src/Google.re
+++ b/packages/reason-expo/src/Google.re
@@ -1,20 +1,41 @@
 [@bs.deriving abstract]
-type logInAsyncOptions = {
-  behavior: string,
-  scopes: array(string),
-  androidClientId: string,
+type logInConfig = {
+  [@bs.optional]
   iosClientId: string,
-  androidStandaloneAppClientId: string,
+  [@bs.optional]
+  androidClientId: string,
+  [@bs.optional]
   iosStandaloneAppClientId: string,
-  webClientId: string,
+  [@bs.optional]
+  androidStandaloneAppClientId: string,
+  [@bs.optional]
+  scopes: array(string),
+  [@bs.optional]
+  redirectUrl: string,
+  [@bs.optional]
+  mutable accessToken: string,
 };
 
-type profileInformation('profileInformationType) = 'profileInformationType;
-
-[@bs.deriving abstract]
-type logInAsyncResult('logInAsyncResultType) = 'logInAsyncResultType;
+type logInResult = {
+  .
+  "_type": string,
+  "accessToken": string,
+  "idToken": string,
+  "refreshToken": string,
+  "user": googleUser,
+}
+and googleUser = {
+  .
+  "id": string,
+  "name": string,
+  "givenName": string,
+  "familyName": string,
+  "photoUrl": string,
+  "email": string,
+};
 
 [@bs.module "expo-google-app-auth"]
-external logInAsync:
-  logInAsyncOptions => Js.Promise.t(logInAsyncResult('logInAsyncResultType)) =
-  "";
+external logInAsync: logInConfig => Js.Promise.t(logInResult) = "";
+
+[@bs.module "expo-google-app-auth"]
+external logOutAsync: logInConfig => Js.Promise.t('a) = "";


### PR DESCRIPTION
The Google module was requiring you to pass in everything in the loginConfig even though they are all not all needed and have default values and there was a missing binding for the log out method. Cleaned the module up a bit and also added binding for `logOutAsync`.

https://docs.expo.io/versions/latest/sdk/google/

Removed `behaviour` as it's deprecated: `DEPRECATED use expo-google-sign-in for system authentication.`

Tested with this code in `packages/test/src/App.re`

```rust
open ReactNative;
open Expo;

let styles =
  Style.(
    StyleSheet.create({
      "container":
        style(
          ~flex=1.,
          ~justifyContent=`center,
          ~alignItems=`center,
          ~backgroundColor="#F5FCFF",
          (),
        ),
      "instructions": style(~textAlign=`center, ~color="#ffffff", ()),
    })
  );

type logInStatus =
  | Success(accessToken)
  | Cancelled
and accessToken = string;

let config =
  Google.logInConfig(
    ~iosClientId="<YOUR_IOS_CLIENT_ID>",
    ~androidClientId="<YOUR_ANDROID_CLIENT_ID>",
    (),
  );

let logIn = () =>
  Google.logInAsync(config)
  |> Js.Promise.then_(result =>
       if (result##_type == "success") {
         Js.Promise.resolve(Success(result##accessToken));
       } else {
         Js.Promise.resolve(Cancelled);
       }
     );

let logOut = accessToken => {
  config->Google.accessTokenSet(accessToken);
  Google.logOutAsync(config) |> Js.Promise.then_(_ => Js.Promise.resolve());
};

[@react.component]
let app = () => {
  let (accessToken, setAccessToken) = React.useState(() => "");
  <View style=styles##container>
    {switch (accessToken) {
     | "" =>
       <Button
         onPress={_evt =>
           logIn()
           |> Js.Promise.then_(result =>
                switch (result) {
                | Success(token) =>
                  Js.Promise.resolve(setAccessToken(_ => token))
                | Cancelled => Js.Promise.resolve()
                }
              )
           |> ignore
         }
         title="Sign In With Google"
       />
     | _ =>
       <Button
         onPress={_evt =>
           logOut(accessToken)
           |> Js.Promise.then_(_ =>
                Js.Promise.resolve(setAccessToken(_ => ""))
              )
           |> ignore
         }
         title="Log Out"
       />
     }}
  </View>;
};
```